### PR TITLE
use 0.6.0-pre for minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 SIUnits
 FixedPointNumbers
 DSP


### PR DESCRIPTION
`struct` syntax won't work on early 0.6.0-dev versions,
so better so stick with the julia-0.5-compatible versions of the package there