### PR TITLE
readstring is deprecated in Julia 1.0

### DIFF
--- a/src/WAVDisplay.jl
+++ b/src/WAVDisplay.jl
@@ -6,7 +6,7 @@
 function embed_javascript()
     js_path = joinpath(dirname(dirname(@__FILE__)), "deps", "wavesurfer.min.js")
     js_text = open(js_path) do io
-        readstring(io)
+        read(io, String)
     end
     # the javascript file contains the code to add itself to the require module
     # cache under the name 'wavesurfer'


### PR DESCRIPTION
`readstring` seems to be deprecated and moved to `read(io, String)` in Julia 1.0, according to the following issue.

https://github.com/JuliaLang/julia/issues/22793