### PR TITLE
Implemented SignalBase API and changed nframes and nchannels to Signa…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SignalBase = "00c44e92-20f5-44bc-8f45-a1dcef76ba38"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 

--- a/src/SampleBuf.jl
+++ b/src/SampleBuf.jl
@@ -47,11 +47,15 @@ SpectrumBuf(T::Type, sr, len::Quantity, ch) =
 # channel - a set of samples running in parallel
 # frame - a collection of samples from each channel that were sampled simultaneously
 
+# SignalBase methods
+SignalBase.nframes(buf::AbstractSampleBuf) = size(buf.data, 1)
+SignalBase.framerate(buf::AbstractSampleBuf) = buf.samplerate
+SignalBase.nchannels(buf::AbstractSampleBuf{T, 2}) where {T} = size(buf.data, 2)
+SignalBase.nchannels(buf::AbstractSampleBuf{T, 1}) where {T} = 1
+SignalBase.sampletype(buf::AbstractSampleBuf) = eltype(buf.data)
+
 # audio methods
 samplerate(buf::AbstractSampleBuf) = buf.samplerate
-nchannels(buf::AbstractSampleBuf{T, 2}) where {T} = size(buf.data, 2)
-nchannels(buf::AbstractSampleBuf{T, 1}) where {T} = 1
-nframes(buf::AbstractSampleBuf) = size(buf.data, 1)
 
 function samplerate!(buf::AbstractSampleBuf, sr)
     buf.samplerate = sr
@@ -60,8 +64,8 @@ function samplerate!(buf::AbstractSampleBuf, sr)
 end
 
 # define audio methods on raw buffers as well
-nframes(arr::AbstractArray) = size(arr, 1)
-nchannels(arr::AbstractArray) = size(arr, 2)
+SignalBase.nframes(arr::AbstractArray) = size(arr, 1)
+SignalBase.nchannels(arr::AbstractArray) = size(arr, 2)
 
 # it's important to define Base.similar so that range-indexing returns the
 # right type, instead of just a bare array

--- a/src/SampleStream.jl
+++ b/src/SampleStream.jl
@@ -256,7 +256,7 @@ function UpMixSink(wrapped::SampleSink, blocksize=DEFAULT_BLOCKSIZE)
 end
 
 samplerate(sink::UpMixSink) = samplerate(sink.wrapped)
-nchannels(sink::UpMixSink) = 1
+SignalBase.nchannels(sink::UpMixSink) = 1
 Base.eltype(sink::UpMixSink) = eltype(sink.wrapped)
 blocksize(sink::UpMixSink) = size(sink.buf, 1)
 
@@ -296,7 +296,7 @@ function DownMixSink(wrapped::SampleSink, channels, blocksize=DEFAULT_BLOCKSIZE)
 end
 
 samplerate(sink::DownMixSink) = samplerate(sink.wrapped)
-nchannels(sink::DownMixSink) = sink.channels
+SignalBase.nchannels(sink::DownMixSink) = sink.channels
 Base.eltype(sink::DownMixSink) = eltype(sink.wrapped)
 blocksize(sink::DownMixSink) = size(sink.buf, 1)
 
@@ -340,7 +340,7 @@ function ReformatSink(wrapped::SampleSink, T, blocksize=DEFAULT_BLOCKSIZE)
 end
 
 samplerate(sink::ReformatSink) = samplerate(sink.wrapped)
-nchannels(sink::ReformatSink) = nchannels(sink.wrapped)
+SignalBase.nchannels(sink::ReformatSink) = nchannels(sink.wrapped)
 Base.eltype(sink::ReformatSink) = sink.typ
 blocksize(sink::ReformatSink) = nframes(sink.buf)
 
@@ -385,7 +385,7 @@ function ResampleSink(wrapped::SampleSink, sr, blocksize=DEFAULT_BLOCKSIZE)
 end
 
 samplerate(sink::ResampleSink) = sink.samplerate
-nchannels(sink::ResampleSink) = nchannels(sink.wrapped)
+SignalBase.nchannels(sink::ResampleSink) = nchannels(sink.wrapped)
 Base.eltype(sink::ResampleSink) = eltype(sink.wrapped)
 # TODO: implement blocksize for this
 
@@ -428,7 +428,7 @@ end
 SampleBufSource(buf::SampleBuf) = SampleBufSource(buf, 0)
 
 samplerate(source::SampleBufSource) = samplerate(source.buf)
-nchannels(source::SampleBufSource) = nchannels(source.buf)
+SignalBase.nchannels(source::SampleBufSource) = nchannels(source.buf)
 Base.eltype(source::SampleBufSource) = eltype(source.buf)
 
 function unsafe_read!(source::SampleBufSource, buf::Array, frameoffset, framecount)
@@ -451,7 +451,7 @@ end
 SampleBufSink(buf::SampleBuf) = SampleBufSink(buf, 0)
 
 samplerate(sink::SampleBufSink) = samplerate(sink.buf)
-nchannels(sink::SampleBufSink) = nchannels(sink.buf)
+SignalBase.nchannels(sink::SampleBufSink) = nchannels(sink.buf)
 Base.eltype(sink::SampleBufSink) = eltype(sink.buf)
 
 function unsafe_write(sink::SampleBufSink, buf::Array, frameoffset, framecount)

--- a/src/SampledSignals.jl
+++ b/src/SampledSignals.jl
@@ -5,8 +5,9 @@ module SampledSignals
 
 using IntervalSets
 
-using SignalBase
-export nframes, nchannels
+import SignalBase
+import SignalBase: nframes, nchannels, framerate
+export nframes, nchannels, framerate, framerate!
 
 export AbstractSampleBuf, SampleBuf, SpectrumBuf
 export SampleSource, SampleSink
@@ -16,7 +17,6 @@ export SampleBufSource, SampleBufSink
 export SinSource
 export ClosedInterval, ..
 # general methods for types in SampledSignals
-export samplerate, samplerate!
 export domain, channelptr, blocksize, metadata
 export mix!, mix, mono!, mono
 # re-export the useful units

--- a/src/SampledSignals.jl
+++ b/src/SampledSignals.jl
@@ -5,6 +5,9 @@ module SampledSignals
 
 using IntervalSets
 
+using SignalBase
+export nframes, nchannels
+
 export AbstractSampleBuf, SampleBuf, SpectrumBuf
 export SampleSource, SampleSink
 export SampleRate
@@ -13,7 +16,7 @@ export SampleBufSource, SampleBufSink
 export SinSource
 export ClosedInterval, ..
 # general methods for types in SampledSignals
-export samplerate, samplerate!, nchannels, nframes
+export samplerate, samplerate!
 export domain, channelptr, blocksize, metadata
 export mix!, mix, mono!, mono
 # re-export the useful units

--- a/src/SignalGen/SinSource.jl
+++ b/src/SignalGen/SinSource.jl
@@ -21,7 +21,7 @@ end
 SinSource(eltype, samplerate, freq::Real) = SinSource(eltype, samplerate, [freq])
 
 Base.eltype(::SinSource{T}) where T = T
-nchannels(source::SinSource) = length(source.freqs)
+SignalBase.nchannels(source::SinSource) = length(source.freqs)
 samplerate(source::SinSource) = source.samplerate
 
 function unsafe_read!(source::SinSource, buf::Array, frameoffset, framecount)

--- a/src/SignalGen/SinSource.jl
+++ b/src/SignalGen/SinSource.jl
@@ -22,10 +22,10 @@ SinSource(eltype, samplerate, freq::Real) = SinSource(eltype, samplerate, [freq]
 
 Base.eltype(::SinSource{T}) where T = T
 SignalBase.nchannels(source::SinSource) = length(source.freqs)
-samplerate(source::SinSource) = source.samplerate
+SignalBase.framerate(source::SinSource) = source.samplerate
 
 function unsafe_read!(source::SinSource, buf::Array, frameoffset, framecount)
-    inc = 2pi / samplerate(source)
+    inc = 2pi / framerate(source)
     for ch in 1:nchannels(buf)
         f = source.freqs[ch]
         ph = source.phases[ch]

--- a/src/WAVDisplay.jl
+++ b/src/WAVDisplay.jl
@@ -49,7 +49,7 @@ function wavwrite(io::IO, buf::SampleBuf{<:Union{Int16, SAMPLE_TYPE, AbstractFlo
     nbits = 16
     nchans = nchannels(buf)
     blockalign = 2 * nchans
-    sr = round(UInt32, float(samplerate(buf)))
+    sr = round(UInt32, float(framerate(buf)))
     bps = sr * blockalign
     datalength::UInt32 = nframes(buf) * blockalign
 

--- a/test/DummySampleStream.jl
+++ b/test/DummySampleStream.jl
@@ -12,18 +12,18 @@ import Compat: undef
     @testset "supports audio interface" begin
         data = rand(DEFAULT_T, (64, 2))
         source = DummySource(data)
-        @test samplerate(source) == DEFAULT_SR
+        @test framerate(source) == DEFAULT_SR
         @test nchannels(source) == 2
         sink = DummyStereoSink()
-        @test samplerate(sink) == DEFAULT_SR
+        @test framerate(sink) == DEFAULT_SR
         @test nchannels(sink) == 2
         @test eltype(source) == DEFAULT_T
     end
 
     @testset "can be created with non-unit sampling rate" begin
         sink = DummySampleSink(Float32, 48000, 2)
-        @test samplerate(sink) == 48000
+        @test framerate(sink) == 48000
         source = DummySampleSource(48000, Array{Float32}(undef, 16, 2))
-        @test samplerate(source) == 48000
+        @test framerate(source) == 48000
     end
 end

--- a/test/SampleBuf.jl
+++ b/test/SampleBuf.jl
@@ -16,12 +16,12 @@ end
 
     @testset "Supports audio interface" begin
         tbuf = Buf(zeros(TEST_T, 64, 2))
-        @test samplerate(tbuf) == TEST_SR
+        @test framerate(tbuf) == TEST_SR
         @test nchannels(tbuf) == 2
         @test nframes(tbuf) == 64
         @test isapprox(domain(tbuf), ((0:63)/TEST_SR))
-        ret = samplerate!(tbuf, 24000)
-        @test samplerate(tbuf) == 24000
+        ret = framerate!(tbuf, 24000)
+        @test framerate(tbuf) == 24000
         @test ret === tbuf
     end
 
@@ -73,9 +73,9 @@ end
         buf = SampleBuf(arr, TEST_SR)
         # linear indexing gives you a mono buffer
         slice = buf[6:12]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[6:12;], TEST_SR)
-        @test samplerate(buf[:]) == TEST_SR
+        @test framerate(buf[:]) == TEST_SR
         @test buf[:] == SampleBuf(arr[:], TEST_SR)
     end
 
@@ -83,17 +83,17 @@ end
         arr = TEST_T[1:8 9:16]
         buf = SampleBuf(arr, TEST_SR)
         slice = buf[3:6, 1:2]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[3:6 11:14], TEST_SR)
         # make sure it works with a bare colon
         slice = buf[3:6, :]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[3:6 11:14], TEST_SR)
         slice = buf[:, 1:2]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[1:8 9:16], TEST_SR)
         slice = buf[:, :]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[1:8 9:16], TEST_SR)
     end
 
@@ -101,9 +101,9 @@ end
         arr = TEST_T[1:8 9:16]
         buf = SampleBuf(arr, TEST_SR)
         slice = buf[6, 1:2]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(TEST_T[6 14], TEST_SR)
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         slice = buf[3:6, 1]
         @test slice == SampleBuf(TEST_T[3:6;], TEST_SR)
     end
@@ -113,17 +113,17 @@ end
         buf = SampleBuf(arr, TEST_SR)
         # linear indexing gives you a mono buffer
         slice = buf[5..11]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(arr[6:12], TEST_SR)
         slice = buf[1..5, 1]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(arr[2:6, 1], TEST_SR)
         slice = buf[2, 1:2]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         # 0.5 array indexing drops scalar indices, so we use 2:2 instead of 2
         @test slice == SampleBuf(arr[2:2, 1:2], TEST_SR)
         slice = buf[1..5, 1:2]
-        @test samplerate(slice) == TEST_SR
+        @test framerate(slice) == TEST_SR
         @test slice == SampleBuf(arr[2:6, 1:2], TEST_SR)
         # indexing the channels by seconds doesn't make sense
         @test_throws ArgumentError buf[2..6,0..1]
@@ -151,7 +151,7 @@ end
         @test nchannels(buf) == 2
         @test nframes(buf) == 100
         @test eltype(buf) == Float32
-        @test samplerate(buf) == TEST_SR
+        @test framerate(buf) == TEST_SR
     end
 
     @testset "Can be created with a length in seconds" begin
@@ -159,20 +159,20 @@ end
         @test nchannels(buf) == 2
         @test nframes(buf) == TEST_SR/2
         @test eltype(buf) == Float32
-        @test samplerate(buf) == TEST_SR
+        @test framerate(buf) == TEST_SR
 
         buf = SampleBuf(Float32, TEST_SR, 0.5s)
         @test nchannels(buf) == 1
         @test nframes(buf) == TEST_SR/2
         @test eltype(buf) == Float32
-        @test samplerate(buf) == TEST_SR
+        @test framerate(buf) == TEST_SR
     end
 
     @testset "Can be created without units" begin
         buf = SampleBuf(Float32, 48000, 100, 2)
-        @test samplerate(buf) == 48000
+        @test framerate(buf) == 48000
         buf = SampleBuf(Array{Float32}(undef, 100, 2), 48000)
-        @test samplerate(buf) == 48000
+        @test framerate(buf) == 48000
     end
 
     @testset "sub references the original instead of copying" begin
@@ -360,7 +360,7 @@ end
         spec = FFTW.fft(buf)
         @test isa(spec, SpectrumBuf)
         @test eltype(spec) == Complex{TEST_T}
-        @test samplerate(spec) == 512/TEST_SR
+        @test framerate(spec) == 512/TEST_SR
         @test nchannels(spec) == 1
         @test spec == SpectrumBuf(FFTW.fft(arr), 512/TEST_SR)
         buf2 = FFTW.ifft(spec)
@@ -368,7 +368,7 @@ end
         # back to real time signals with ifft
         @test isa(buf2, SampleBuf)
         @test eltype(buf2) == Complex{TEST_T}
-        @test samplerate(buf2) == TEST_SR
+        @test framerate(buf2) == TEST_SR
         @test nchannels(buf2) == 1
         @test isapprox(buf2, buf)
     end

--- a/test/SampleStream.jl
+++ b/test/SampleStream.jl
@@ -173,7 +173,7 @@ include("support/util.jl")
 
     @testset "Partial SampleBufs can be written to sinks specifying frames" begin
         sink = DummyStereoSink()
-        buf = SampleBuf(rand(10, 2), samplerate(sink))
+        buf = SampleBuf(rand(10, 2), framerate(sink))
         write(sink, buf, 5)
         @test sink.buf == buf.data[1:5, :]
     end
@@ -187,8 +187,8 @@ include("support/util.jl")
 
     @testset "Partial SampleBufs can be written to sinks specifying duration" begin
         sink = DummyStereoSink()
-        buf = SampleBuf(rand(10, 2), samplerate(sink))
-        t = 5/samplerate(sink) * s
+        buf = SampleBuf(rand(10, 2), framerate(sink))
+        t = 5/framerate(sink) * s
         write(sink, buf, t)
         @test sink.buf == buf.data[1:5, :]
     end
@@ -196,7 +196,7 @@ include("support/util.jl")
     @testset "Partial Arrays can be written to sinks specifying duration" begin
         sink = DummyStereoSink()
         buf = rand(10, 2)
-        t = 5/samplerate(sink) * s
+        t = 5/framerate(sink) * s
         write(sink, buf, t)
         @test sink.buf == buf[1:5, :]
     end
@@ -227,7 +227,7 @@ include("support/util.jl")
     @testset "read can read in seconds" begin
         data = rand(20, 2)
         source = DummySource(data)
-        t = 5/samplerate(source) * s
+        t = 5/framerate(source) * s
         buf = read(source, t)
         @test buf.data == data[1:5, :]
     end
@@ -244,7 +244,7 @@ include("support/util.jl")
     @testset "can read! into SampleBuf specifying frames" begin
         data = rand(8, 2)
         source = DummySource(data)
-        buf = SampleBuf(zeros(8, 2), samplerate(source))
+        buf = SampleBuf(zeros(8, 2), framerate(source))
         @test read!(source, buf, 5) == 5
         @test buf.data[1:5, :] == data[1:5, :]
         @test buf.data[6:8, :] == zeros(3, 2)
@@ -254,7 +254,7 @@ include("support/util.jl")
         data = rand(8, 2)
         source = DummySource(data)
         buf = zeros(8, 2)
-        t = 5/samplerate(source) * s
+        t = 5/framerate(source) * s
         @test read!(source, buf, t) == t
         @test buf[1:5, :] == data[1:5, :]
         @test buf[6:8, :] == zeros(3, 2)
@@ -263,8 +263,8 @@ include("support/util.jl")
     @testset "can read! into SampleBuf specifying time" begin
         data = rand(8, 2)
         source = DummySource(data)
-        buf = SampleBuf(zeros(8, 2), samplerate(source))
-        t = 5/samplerate(source) * s
+        buf = SampleBuf(zeros(8, 2), framerate(source))
+        t = 5/framerate(source) * s
         @test read!(source, buf, t) == t
         @test buf.data[1:5, :] == data[1:5, :]
         @test buf.data[6:8, :] == zeros(3, 2)
@@ -281,7 +281,7 @@ include("support/util.jl")
     @testset "can read! into SampleBuf without specifying frames" begin
         data = rand(8, 2)
         source = DummySource(data)
-        buf = SampleBuf(rand(5, 2), samplerate(source))
+        buf = SampleBuf(rand(5, 2), framerate(source))
         @test read!(source, buf) == 5
         @test buf.data == data[1:5, :]
     end
@@ -298,7 +298,7 @@ include("support/util.jl")
     @testset "can read! into too-long SampleBuf without specifying frames" begin
         data = rand(8, 2)
         source = DummySource(data)
-        buf = SampleBuf(zeros(10, 2), samplerate(source))
+        buf = SampleBuf(zeros(10, 2), framerate(source))
         @test read!(source, buf) == 8
         @test buf[1:8, :] == data
         @test buf[9:10, :] == zeros(2, 2)
@@ -406,7 +406,7 @@ include("support/util.jl")
 
     @testset "Writing source to sink goes blockwise" begin
         source = BlockedSampleSource(32)
-        sink = DummySampleSink(eltype(source), samplerate(source), nchannels(source))
+        sink = DummySampleSink(eltype(source), framerate(source), nchannels(source))
         write(sink, source)
         @test size(sink.buf, 1) == 32
         for ch in 1:nchannels(source), i in 1:16

--- a/test/WAVDisplay.jl
+++ b/test/WAVDisplay.jl
@@ -9,7 +9,7 @@
         seekstart(io)
         readbuf = loadwav(io)
         @test reinterpret.(readbuf) == buf
-        @test samplerate(readbuf) == 48000
+        @test framerate(readbuf) == 48000
         @test eltype(readbuf) == Fixed{Int16, 15}
     end
 
@@ -20,7 +20,7 @@
         seek(io, 0)
         readbuf = loadwav(io)
         @test readbuf == buf
-        @test samplerate(readbuf) == 48000
+        @test framerate(readbuf) == 48000
         @test eltype(readbuf) == Fixed{Int16, 15}
     end
 
@@ -31,7 +31,7 @@
         seekstart(io)
         readbuf = loadwav(io)
         @test readbuf == PCM16Sample.(buf)
-        @test samplerate(readbuf) == 48000
+        @test framerate(readbuf) == 48000
         @test eltype(readbuf) == Fixed{Int16, 15}
     end
 
@@ -44,7 +44,7 @@
         readbuf = loadwav(io)
         # convert 32-bit int buf to float, then to 16-bit, for testing
         @test readbuf == PCM16Sample.(Float32.(buf))
-        @test samplerate(readbuf) == 48000
+        @test framerate(readbuf) == 48000
         @test eltype(readbuf) == Fixed{Int16, 15}
     end
 end

--- a/test/support/util.jl
+++ b/test/support/util.jl
@@ -1,4 +1,6 @@
-import SampledSignals: blocksize, samplerate, nchannels, unsafe_read!, unsafe_write
+import SignalBase
+import SignalBase: framerate, nchannels
+import SampledSignals: blocksize, unsafe_read!, unsafe_write
 import Base: eltype
 
 mutable struct DummySampleSource{T} <: SampleSource
@@ -7,8 +9,8 @@ mutable struct DummySampleSource{T} <: SampleSource
 end
 
 DummySampleSource(sr, buf::Array{T}) where T = DummySampleSource{T}(sr, buf)
-samplerate(source::DummySampleSource) = source.samplerate
-nchannels(source::DummySampleSource) = size(source.buf, 2)
+SignalBase.framerate(source::DummySampleSource) = source.samplerate
+SignalBase.nchannels(source::DummySampleSource) = size(source.buf, 2)
 Base.eltype(source::DummySampleSource{T}) where T = T
 
 function unsafe_read!(src::DummySampleSource, buf::Array, frameoffset, framecount)
@@ -31,8 +33,8 @@ end
 DummySampleSink(eltype, samplerate, channels) =
     DummySampleSink{eltype}(samplerate, Array{eltype}(undef, 0, channels))
 
-samplerate(sink::DummySampleSink) = sink.samplerate
-nchannels(sink::DummySampleSink) = size(sink.buf, 2)
+SignalBase.framerate(sink::DummySampleSink) = sink.samplerate
+SignalBase.nchannels(sink::DummySampleSink) = size(sink.buf, 2)
 Base.eltype(sink::DummySampleSink{T}) where T = T
 
 function SampledSignals.unsafe_write(sink::DummySampleSink, buf::Array,
@@ -64,9 +66,9 @@ mutable struct BlockedSampleSource <: SampleSource
 end
 
 blocksize(::BlockedSampleSource) = 16
-samplerate(::BlockedSampleSource) = 48.0
+SignalBase.framerate(::BlockedSampleSource) = 48.0
 eltype(::BlockedSampleSource) = Float32
-nchannels(::BlockedSampleSource) = 2
+SignalBase.nchannels(::BlockedSampleSource) = 2
 
 function unsafe_read!(src::BlockedSampleSource, buf::Array, frameoffset, framecount)
     @test framecount == blocksize(src)


### PR DESCRIPTION
As discussed in #56, I've implemented the `SignalBase` API for `AbstractSampleBuf`.

This replaces `nframes` and `nchannels` from `SampledSignals` with the ones from `SignalBase`, and re-exports them. The `SampledSignals.samplerate` and `SampledSignals.samplerate!` APIs are left alone for backward compatibility. Other APIs (`SignalBase.framerate` and `SignalBase.sampletype`) are also implemented, but not re-exported, since they were not defined in `SampledSignals` to begin with.

All tests pass.