### PR TITLE
Fix downgrade of packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Compat = "2"
+Compat = "2, 3"
 DSP = "0.6.1"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1"


### PR DESCRIPTION
I think this is correct syntax but it's not tested.

I was adding LibSndFile but this package seems to be the cause (or Compat). I think their reason for version 3 is just to simplify code (issue 651), dropping support for Julia 0.7, and you would keep it if you allow Compat 2.x.

If this works, please tag a release.