### PR TITLE
Fix depreciation warnings and fix requirements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "bd7594eb-a658-542f-9e75-4c4d8908c167"
 version = "2.1.1"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
@@ -18,28 +19,19 @@ DSP = "0.6.1"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1"
 IntervalSets = "0.3.2"
+TreeViews = "0.3"
 Unitful = "0.17.0"
 julia = "1"
-TreeViews = "0.3"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-# LibSndFile = "b13ce0c6-77b0-50c6-a2db-140568b8d1a5"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
-IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["DSP",
-        "FileIO",
-        "FixedPointNumbers",
-        # "LibSndFile",
-        "Unitful",
-        "Compat",
-        "SampledSignals",
-        "TreeViews",
-        "IntervalSets"]
+test = ["DSP", "FileIO", "FixedPointNumbers", "Unitful", "Compat", "SampledSignals", "TreeViews", "IntervalSets"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,14 +25,8 @@ Unitful = "0.17.0"
 julia = "1"
 
 [extras]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
-SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
-TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DSP", "FileIO", "FixedPointNumbers", "Unitful", "Compat", "SampledSignals", "TreeViews", "IntervalSets"]
+test = ["Test", "FileIO"]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Tests](https://github.com/JuliaAudio/SampledSignals.jl/actions/workflows/Tests.yml/badge.svg?branch=master)](https://github.com/JuliaAudio/SampledSignals.jl/actions/workflows/Tests.yml)
 [![codecov.io](http://codecov.io/github/JuliaAudio/SampledSignals.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaAudio/SampledSignals.jl?branch=master)
 
-**Dev Note: Currently the master branch of SampledSignals requires the master branch of LibSndFile for its tests.**
-
 SampledSignals is a collection of types intended to be used on multichannel sampled signals like audio or radio data, EEG signals, etc., to provide better interoperability between packages that read data from files or streams, DSP packages, and output and display packages.
 
 SampledSignals provides several types to stream and store sampled data: `SampleBuf`, `SpectrumBuf`, `SampleSource`, `SampleSink` which make use of [IntervalSets](https://github.com/JuliaMath/IntervalSets.jl) that can be used to represent contiguous ranges using a convenient `a..b` syntax, this feature is copied mostly from the [AxisArrays](https://github.com/mbauman/AxisArrays.jl) package, which also inspired much of the implementation of this package.
@@ -158,17 +156,3 @@ Currently for real-valued indices like time we are just rounding to the nearest 
 ### Relative vs. Absolute indexing
 
 When we take a slice of a SampleBuf (e.g. take the span from 1s to 3s of a 10s audio buffer), what is the indexing domain of the result? Specifically, is it 1s-3s, or is it 0s-2s? For time-domain signals I can see wanting indexing relative to the beginning of the buffer, but in frequency-domain buffers it seems you usually want to keep the frequency information. Keeping track of the time information could also be useful if you split out a signal for processing and then want to re-combine things at the end.
-
-## AbstractTrees troubleshooting
-
-To run the SampledSignals tests you need Gumbo, but installing both Gumbo and Juno causes issues that prevent you from running the tests on 0.6. Here are the details:
-
-* AbstractTrees < v0.1.0 is not compatible with Julia v0.6
-* Gumbo 0.3.0 (latest) requires AbstractTrees >= v0.0.4
-* ASTInterpreter requires AbstractTrees between v0.0.4 and v0.1.0
-    * this limitation isn't in the REQUIRE in the repo, but was added to METADATA
-* ASTInterpreter is required by Atom and Gallium
-
-### Solution:
-
-Run `Pkg.checkout("ASTInterpreter")` and `Pkg.resolve()` until a new version is tagged. The ASTInterpreter tests don't pass, but it gets things working enough to get AbstractTrees back to 0.1.0 and the SampledSignals tests runnable.

--- a/src/SampledSignals.jl
+++ b/src/SampledSignals.jl
@@ -27,8 +27,8 @@ using FixedPointNumbers
 using DSP
 using Compat
 using Compat: AbstractRange, undef, range
-using Compat.Random: randstring
-using Compat.Base64: base64encode
+using Random: randstring
+using Base64: base64encode
 using TreeViews: TreeViews
 
 if VERSION >= v"0.7.0-DEV"

--- a/test/DummySampleStream.jl
+++ b/test/DummySampleStream.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 import Compat: undef
 
 @testset "DummySampleStream Tests" begin

--- a/test/SampleBuf.jl
+++ b/test/SampleBuf.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 using Compat: undef, range
 using SampledSignals
 using Unitful

--- a/test/SampleStream.jl
+++ b/test/SampleStream.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 import Compat: undef
 using SampledSignals
 using DSP

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SampledSignals
-using Compat.Test
+using Test
 using DSP
 using FixedPointNumbers
 using FileIO: File, Stream, @format_str


### PR DESCRIPTION
This should remove the depreciation warnings that are currently thrown in the tests. In fixing these depreciation warnings I have added the required packages to Project.toml and tidied the testing section.