### PR TITLE
Make compatibile with DSP 0.7.*

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,14 +25,16 @@ jobs:
           - '1.4'
           - '1.5'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
-
+        include:
+          - version: "nightly"
+            experimental: true
+  
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,7 +13,6 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,15 +24,13 @@ jobs:
           - '1.4'
           - '1.5'
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
-        include:
-          - version: "nightly"
-            experimental: true
   
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Compat = "2, 3"
-DSP = "0.6.1, 0.7.1"
+DSP = "0.6.1, 0.7.0"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SampledSignals"
 uuid = "bd7594eb-a658-542f-9e75-4c4d8908c167"
-version = "2.1.3"
+version = "2.1.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -16,7 +16,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Compat = "2, 3"
-DSP = "0.6.1, 0.7.0"
+DSP = "0.6.1, 0.7"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SampledSignals"
 uuid = "bd7594eb-a658-542f-9e75-4c4d8908c167"
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Compat = "2, 3"
-DSP = "0.6.1, 0.7"
+DSP = "0.6.1, 0.7.1"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5"

--- a/test/SampleBuf.jl
+++ b/test/SampleBuf.jl
@@ -404,7 +404,7 @@ end
                      0 0.5]
         out = mix(arr, mixmatrix)
         @test isapprox(out[:, 1], arr[:, 1])
-        @test isapprox(out[:, 2], 0.5(arr[:, 2]+arr[:, 3]))
+        @test isapprox(out[:, 2], TEST_T(0.5) * (arr[:, 2]+arr[:, 3]))
     end
 
 
@@ -418,7 +418,7 @@ end
             out = mix(buf, mixmatrix)
             @test isa(out, T)
             @test isapprox(out[:, 1], T(arr[:, 1], TEST_SR))
-            @test isapprox(out[:, 2], T(0.5(arr[:, 2]+arr[:, 3]), TEST_SR))
+            @test isapprox(out[:, 2], T(TEST_T(0.5) * (arr[:, 2]+arr[:, 3]), TEST_SR))
         end
     end
 
@@ -430,7 +430,7 @@ end
                      0 0.5]
         mix!(out, arr, mixmatrix)
         @test isapprox(out[:, 1], arr[:, 1])
-        @test isapprox(out[:, 2], 0.5(arr[:, 2]+arr[:, 3]))
+        @test isapprox(out[:, 2], TEST_T(0.5) * (arr[:, 2]+arr[:, 3]))
     end
 
 
@@ -444,13 +444,13 @@ end
             buf = T(arr, TEST_SR)
             out = mix(buf, mixmatrix)
             @test isa(out, T)
-            @test out == T(arr * mixmatrix, TEST_SR)
+            @test isapprox(out, T(arr * mixmatrix, TEST_SR))
         end
     end
 
     @testset "Arrays support mono" begin
         arr = rand(TEST_T, 8, 2)
-        @test isapprox(mono(arr), 0.5(arr[:, 1] + arr[:, 2]))
+        @test isapprox(mono(arr), TEST_T(0.5) * (arr[:, 1] + arr[:, 2]))
     end
 
     @testset "SampleBufs and SpectrumBufs support mono" begin
@@ -459,7 +459,7 @@ end
             buf = T(arr, TEST_SR)
             out = mono(buf)
             @test isa(out, T)
-            @test isapprox(out, 0.5(buf[:, 1] + buf[:, 2]))
+            @test isapprox(out, TEST_T(0.5) * (buf[:, 1] + buf[:, 2]))
         end
     end
 
@@ -467,7 +467,7 @@ end
         arr = rand(TEST_T, 8, 2)
         out = zeros(TEST_T, 8)
         mono!(out, arr)
-        @test isapprox(out, 0.5(arr[:, 1] + arr[:, 2]))
+        @test isapprox(out, TEST_T(0.5) * (arr[:, 1] + arr[:, 2]))
     end
 
     @testset "SampleBufs and SpectrumBufs support mono!" begin
@@ -476,7 +476,7 @@ end
             buf = T(arr, TEST_SR)
             out = T(TEST_T, TEST_SR, 8)
             mono!(out, buf)
-            @test isapprox(out, 0.5(buf[:, 1] + buf[:, 2]))
+            @test isapprox(out, TEST_T(0.5) * (buf[:, 1] + buf[:, 2]))
         end
     end
 
@@ -486,8 +486,8 @@ end
         out2 = zeros(TEST_T, 8, 1)
         mono!(out1, arr)
         mono!(out2, arr)
-        @test isapprox(out1, 0.5(arr[:, 1] + arr[:, 2]))
-        @test isapprox(out2, 0.5(arr[:, 1] + arr[:, 2]))
+        @test isapprox(out1, TEST_T(0.5) * (arr[:, 1] + arr[:, 2]))
+        @test isapprox(out2, TEST_T(0.5) * (arr[:, 1] + arr[:, 2]))
     end
 
     @testset "multichannel buf prints prettily" begin


### PR DESCRIPTION
#### What does this implement/fix? 
- Makes all versions of DSP 0.7.x compatible with SampledSignals.
- Fixes some floating point comparisons in the SampleBuf tests.


#### Reference issue
Fixes #86.


#### Additional information
[Behavior of versions with leading zeros](https://pkgdocs.julialang.org/v1/compatibility/#compat-pre-1.0)
