### PR TITLE
Add compatibility for DSP 0.7.*

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SampledSignals"
 uuid = "bd7594eb-a658-542f-9e75-4c4d8908c167"
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Compat = "2, 3"
-DSP = "0.6.1, 0.7"
+DSP = "0.6.1 - 0.7"
 FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5"


### PR DESCRIPTION
Installing SampledSignals forces me to downgrade a number of other packages. The culprit is the compatibility with the DSP package. Installing SampledSignals forces me to downgrade to DSP v0.6.10 from DSP v0.7.4. I would like this fix to be merged so I am not forced to downgrade DSP.

See below: `restricted by compatibility requirements with SampledSignals [bd7594eb] to versions: 0.6.1-0.6.10 — no versions left`

```
(@v1.7) pkg> add DSP@0.7.4
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package DSP [717857b8]:
 DSP [717857b8] log:
 ├─possible versions are: 0.5.1-0.7.4 or uninstalled
 ├─restricted to versions 0.7.4 by an explicit requirement, leaving only versions 0.7.4
 └─restricted by compatibility requirements with SampledSignals [bd7594eb] to versions: 0.6.1-0.6.10 — no versions left
   └─SampledSignals [bd7594eb] log:
     ├─possible versions are: 2.0.0-2.1.2 or uninstalled
     ├─restricted to versions * by an explicit requirement, leaving only versions 2.0.0-2.1.2
     └─restricted by compatibility requirements with PortAudio [80ea8bcb] to versions: 2.1.1-2.1.2
       └─PortAudio [80ea8bcb] log:
         ├─possible versions are: 1.1.1-1.1.2 or uninstalled
         └─restricted to versions * by an explicit requirement, leaving only versions 1.1.1-1.1.2
```