### PR TITLE
Updated version requirement to julia (1.6) & unitful (1.11)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SampledSignals"
 uuid = "bd7594eb-a658-542f-9e75-4c4d8908c167"
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -21,8 +21,8 @@ FFTW = "1.1.0"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5, 0.6"
 TreeViews = "0.3"
-Unitful = "0.17.0, 0.18, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7"
-julia = "1"
+Unitful = "0.17.0, 0.18, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11"
+julia = "1.6"
 
 [extras]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IntervalSets = "0.3.2, 0.4, 0.5, 0.6"
 TreeViews = "0.3"
 Unitful = "0.17.0, 0.18, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11"
-julia = "1.6"
+julia = "1"
 
 [extras]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SampledSignals adds the `domain` function for `SampleBuf`s, which gives you the 
 
 ```julia
 spec = fft(buf)
-plot(domain(spec), abs(spec))
+plot(domain(spec), abs.(spec.data))
 ```
 
 and see the magnitude spectrum plotted against actual frequencies.


### PR DESCRIPTION
#### What does this implement/fix? 
This PR updates the version requirement to julia 1.6 and compatibility with Unitful 1.11. These changes allow IntervalSets to be updated from 0.5.4 to the latest version of 0.6.1. 


#### Reference issue
Fixes https://github.com/JuliaAudio/SampledSignals.jl/issues/92

